### PR TITLE
fix: resolve nextra shallow clone warning and improve docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Problem
The documentation deployment was experiencing issues due to a shallow git clone warning from Nextra:

\`\`\`
[nextra] The repository is shallow cloned, so the latest modified time will not be presented.
\`\`\`

## Solution
- Changed \`fetch-depth\` from \`2\` to \`0\` in the GitHub Actions checkout step
- This fetches the full git history, allowing Nextra to properly determine file modification times
- Resolves the shallow clone warning and ensures proper documentation generation

## Changes
- Updated \`.github/workflows/docs.yml\` to use \`fetch-depth: 0\`

## Testing
This should resolve the documentation deployment issues and eliminate the Nextra warning during the build process.