### PR TITLE
fix: GitHub Pages deployment workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,23 +89,45 @@ jobs:
       - run: pnpm turbo run type-check --affected
       - run: pnpm turbo run build --affected
       - run: pnpm turbo run test --affected
+
+      # Debug: Check what was built
+      - name: Check build output
+        run: |
+          echo "Checking packages directory structure:"
+          find packages -name "dist" -type d || echo "No dist directories found"
+          ls -la packages/*/dist 2>/dev/null || echo "No dist directories to list"
           
       - uses: actions/upload-artifact@v4
+        if: success()
         with:
           name: build-artifacts
           path: packages/*/dist
+          if-no-files-found: warn
 
   cache-build:
     name: Cache Artifacts
     needs: validate
     runs-on: ubuntu-latest
+    if: success()
     steps:
       - uses: actions/download-artifact@v4
+        id: download-artifacts
+        continue-on-error: true
         with:
           name: build-artifacts
           path: packages
 
+      - name: Check artifact download
+        run: |
+          if [[ "${{ steps.download-artifacts.outcome }}" == "success" ]]; then
+            echo "Artifacts downloaded successfully"
+            ls -la packages/
+          else
+            echo "No artifacts to download - this may be expected if no packages were built"
+          fi
+
       - uses: actions/cache@v4
+        if: steps.download-artifacts.outcome == 'success'
         with:
           path: packages/*/dist
           key: build-artifacts-${{ github.sha }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           path: packages/*/dist
           key: build-artifacts-${{ github.sha }}
+          restore-keys: |
+            build-artifacts-
 
       - id: cache-node-modules
         uses: actions/cache@v4
@@ -62,8 +64,9 @@ jobs:
       # This ensures workspace packages like docs have their dependencies
       - run: pnpm install --frozen-lockfile
 
+      # Always build packages to ensure we have the latest changes
+      # Don't rely solely on cache as it might be stale or missing
       - run: pnpm turbo run build
-        if: steps.cached-build-artifacts.outputs.cache-hit != 'true'
 
       - run: pnpm turbo run docgen --filter=@evolution-sdk/evolution
 
@@ -81,7 +84,17 @@ jobs:
       # Add debug step to check if the output directory exists
       - name: Debug output directory
         run: |
+          echo "Checking docs build output:"
           ls -la docs/
+          if [ -d "docs/out" ]; then
+            echo "docs/out directory exists:"
+            ls -la docs/out/
+            echo "Total files in docs/out:"
+            find docs/out -type f | wc -l
+          else
+            echo "ERROR: docs/out directory does not exist!"
+            exit 1
+          fi
           
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Problem
The GitHub Pages site wasn't updating properly due to workflow dependency issues and artifact handling problems.

## Changes
### CI Workflow (`ci.yml`)
- Added debug output to check what gets built
- Made artifact upload conditional with warning for missing files
- Added error handling for artifact download in cache-build job
- Made caching conditional based on successful artifact download

### Docs Workflow (`docs.yml`)
- Removed hard dependency on potentially missing build artifacts cache
- Always run build to ensure latest packages are available
- Added restore-keys for build artifacts cache as fallback
- Added comprehensive debug output for docs build process
- Added validation to ensure docs/out directory exists before upload

## Testing
These changes should resolve the GitHub Pages deployment issues by:
1. Making the CI workflow more robust with artifact handling
2. Ensuring the docs workflow can build independently
3. Adding better error detection and debugging output

The workflows will now be more resilient to cache misses and build failures.