### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,55 +15,39 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Release
+    name: 🚀 Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
         with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org/'
 
-      - id: cached-build-artifacts
-        uses: actions/cache@v4
-        with:
-          path: packages/*/dist
-          key: build-artifacts-${{ github.sha }}
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            docs/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-modules-
-            
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - name: 🏗 Build packages
+        run: pnpm turbo run build
 
-      # Always run install to ensure all dependencies are available
-      # This ensures workspace packages like docs have their dependencies
-      - run: pnpm install --frozen-lockfile
+      - name: 🧪 Run tests
+        run: pnpm turbo run test
 
-      - run: pnpm turbo run build
-        if: steps.cached-build-artifacts.outputs.cache-hit != 'true'
-
-      - id: changesets
+      - name: 🦋 Create Release Pull Request or Publish to npm
+        id: changesets
         uses: changesets/action@v1
         with:
+          # This uses our custom publish script that builds before publishing
           publish: pnpm changeset-publish
           title: "ci(changesets): version packages"
           commit: "ci(changesets): version packages"


### PR DESCRIPTION
- Remove complex caching logic
- Remove Slack notification step
- Remove docgen step from release process
- Keep it focused on core release tasks: build, test, publish